### PR TITLE
fix bug when someone select a revisor twice the other commands stop working

### DIFF
--- a/src/commands/pulls/pulls.ts
+++ b/src/commands/pulls/pulls.ts
@@ -128,7 +128,7 @@ export async function execute(interaction: CommandInteraction, client: Client) {
       const messages = await thread.messages.fetchPinned()
 
       const messageInfo = messages.at(0)
-      console.log(messageInfo)
+
       if (
         !messageInfo ||
         !messageInfo.content.includes(pullID.value?.toString()!)

--- a/src/commands/pulls/pulls.ts
+++ b/src/commands/pulls/pulls.ts
@@ -125,7 +125,16 @@ export async function execute(interaction: CommandInteraction, client: Client) {
         components: [row],
       })
 
-      await pinMessage(thread)
+      const messages = await thread.messages.fetchPinned()
+
+      const messageInfo = messages.at(0)
+      console.log(messageInfo)
+      if (
+        !messageInfo ||
+        !messageInfo.content.includes(pullID.value?.toString()!)
+      ) {
+        await pinMessage(thread)
+      }
     })
   } catch (error) {
     return interaction.reply({


### PR DESCRIPTION
Closes #42 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

fix bug when someone select a revisor twice the other commands stop working because it was pinning the message twice

</details>

<details open> 
  <summary>
    <b>Bugfix</b>
  </summary>

- **Description**
when someone select a revisor twice the other commands stop working 

- **Cause**
because the bot takes the pinned message to use as reference for other commands and when you select someone twice it was pinning the message twice and the pin flow is broken

- **Solution**
now the message with the information necessary is only pinned if dont have the same message pinned before
</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [x] Issue linked
- [x] Build working correctly
- [ ] Tests created
</details>

