### PR TITLE
Create email command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,19 @@ DISCORD_PETDEX_CHANNEL="id canal avisos petdex"
 DISCORD_OCTOPOST_CHANNEL="id canal avisos octopost"
 DISCORD_PETDEX_ROLE="id cargo petdex"
 DISCORD_OCTOPOST_ROLE="id cargo octopost"
+
+# Emails
+  ALECELL='',
+  NICOLETTI='',
+  TRINDADE='',
+  ANDRE='',
+  ZOLDICAS='',
+  PILU='',
+  HX='',
+  NESS='',
+  LEFEL='',
+  ALVARO='',
+  JOTAPE='',
+  KEVIN='',
+  DIOGO='',
+  K1NHA='',

--- a/src/commands/emails/emails.ts
+++ b/src/commands/emails/emails.ts
@@ -1,0 +1,49 @@
+import {
+  ActionRowBuilder,
+  CommandInteraction,
+  ComponentType,
+  SlashCommandBuilder,
+  StringSelectMenuBuilder,
+} from 'discord.js'
+import { TObjectKeyAsType } from '../../types/email'
+import { Emails, processEmails } from './utils/processSlang'
+import { slangOptions } from './utils/slangOptions'
+
+export const data = new SlashCommandBuilder()
+  .setName('emails')
+  .setDescription('Emails de membros da staff')
+
+export async function execute(interaction: CommandInteraction) {
+  const allOptions = slangOptions(Emails)
+
+  const selectEmail = new StringSelectMenuBuilder()
+    .setCustomId(`select-membro`)
+    .setPlaceholder('Selecione um membro da staff')
+    .addOptions(allOptions)
+
+  const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+    selectEmail
+  )
+
+  const emailButton = await interaction.reply({
+    content: `Emails da staff`,
+    components: [row],
+    ephemeral: true,
+  })
+
+  const collector = emailButton.createMessageComponentCollector({
+    componentType: ComponentType.StringSelect,
+    time: 60000,
+  })
+
+  collector.on('collect', async (interaction) => {
+    const emailSelected = processEmails(
+      interaction.values[0] as TObjectKeyAsType<typeof Emails>
+    )
+
+    await interaction.reply({
+      content: `Email: ${emailSelected}`,
+      ephemeral: true,
+    })
+  })
+}

--- a/src/commands/emails/utils/processSlang.ts
+++ b/src/commands/emails/utils/processSlang.ts
@@ -1,0 +1,22 @@
+import { TObjectKeyAsType } from '../../../types/email'
+
+export const Emails = {
+  Dono: process.env.ALECELL,
+  'Primogênito do dono': process.env.NICOLETTI,
+  Trindade: process.env.TRINDADE,
+  'André King': process.env.ANDRE,
+  Zoldicas: process.env.ZOLDICAS,
+  Pilu: process.env.PILU,
+  HX: process.env.HX,
+  'Peter Parker': process.env.NESS,
+  Lefel: process.env.LEFEL,
+  'Filho do Dono': process.env.ALVARO,
+  'Novinha vc é uma delicinha': process.env.JOTAPE,
+  'Kevin e o Cris': process.env.KEVIN,
+  Caronte: process.env.DIOGO,
+  'É o KINHA MEU PARCEIRO': process.env.K1NHA,
+}
+
+export function processEmails(option: TObjectKeyAsType<typeof Emails>) {
+  return Emails[option]
+}

--- a/src/commands/emails/utils/slangOptions.ts
+++ b/src/commands/emails/utils/slangOptions.ts
@@ -1,0 +1,10 @@
+import { TSelectSlang } from '../../../types/email'
+
+export function slangOptions(slangs: object) {
+  const slangOptions: TSelectSlang[] = []
+  Object.keys(slangs).map((slang) => {
+    slangOptions.push({ label: slang, value: slang })
+  })
+
+  return slangOptions
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,6 @@
-export * as girias from './girias/girias'
-export * as pulls from './pulls/pulls'
 export * as approve from './approve/approve'
 export * as changes from './changes/changes'
+export * as emails from './emails/emails'
+export * as girias from './girias/girias'
+export * as pulls from './pulls/pulls'
 export * as rereview from './rereview/rereview'

--- a/src/types/email.ts
+++ b/src/types/email.ts
@@ -1,0 +1,3 @@
+export type TObjectKeyAsType<T extends object> = keyof T
+
+export type TSelectSlang = { label: string; value: string }


### PR DESCRIPTION
Closes #38 

<details open> 
  <summary>
    <b>Feature</b>
  </summary>

Criação de um comando onde quando precisar podemos ver o email de todos da staff, somente pode usar quem é clube hatter pra cima(Ainda falta implementar isso)

</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>

![image](https://github.com/devhatt/hatbot-discord/assets/69992923/b9c65256-da8e-4644-a4b4-01ece39229e0)

![image](https://github.com/devhatt/hatbot-discord/assets/69992923/7dfb1214-648d-4256-9b5c-8721d41b8794)

![image](https://github.com/devhatt/hatbot-discord/assets/69992923/d9c5c485-8de2-4c4d-aa34-d145f1d2d28f)

![image](https://github.com/devhatt/hatbot-discord/assets/69992923/ab678a8a-926f-4fd0-a536-9e82617888de)


</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

- [x] Issue linked
- [x] Build working correctly
- [x] Tests created
</details>

<details open> 
  <summary>
    <b>Additional info</b>
  </summary>

Usei de base o comando de girias do @hxsggsz, se quiser alguma nova função ou que mude o comportamento é só falar 
</details>
